### PR TITLE
Initialize processed and valid flags in metadata after download

### DIFF
--- a/R/download-marketdata.R
+++ b/R/download-marketdata.R
@@ -125,6 +125,8 @@ finalize_download <- function(filename, dest_fname, meta, ext) {
   }
   meta_add_download(meta) <- downloaded
   meta_set_downloaded(meta) <- TRUE
+  meta_set_processed(meta) <- FALSE
+  meta_set_valid(meta) <- FALSE
   meta
 }
 


### PR DESCRIPTION
In the file download-marketdata.R, the function finalize_download was changed to set processed and valid flags after executing a download.